### PR TITLE
feat: user database

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,10 @@
+# Use the official PostgreSQL image from the Docker Hub
+FROM postgres:latest
+
+# Environment variables for the default database and user
+ENV POSTGRES_DB=pokemon_db
+ENV POSTGRES_USER=youruser
+ENV POSTGRES_PASSWORD=yourpassword
+
+# Copy the initialization SQL script to the Docker image
+COPY init.sql /docker-entrypoint-initdb.d/

--- a/backend/init.sql
+++ b/backend/init.sql
@@ -1,0 +1,33 @@
+-- Create the database
+CREATE DATABASE pokemon_db;
+
+-- Connect to the database
+\c pokemon_db;
+
+-- Create the users table
+CREATE TABLE users (
+    user_id SERIAL PRIMARY KEY,
+    username VARCHAR(50) UNIQUE NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create the favorites table
+CREATE TABLE favorites (
+    user_id INT NOT NULL,
+    pokemon_id INT NOT NULL,
+    PRIMARY KEY (user_id, pokemon_id),
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);
+
+-- Insert fake users
+INSERT INTO users (username, password_hash) VALUES 
+('trainer1', 'hashed_password1'),
+('trainer2', 'hashed_password2');
+
+-- Insert fake favorites for users (example PokeAPI IDs)
+INSERT INTO favorites (user_id, pokemon_id) VALUES 
+(1, 1), -- trainer1 favorites Bulbasaur (PokeAPI ID 1)
+(1, 4), -- trainer1 favorites Charmander (PokeAPI ID 4)
+(2, 7); -- trainer2 favorites Squirtle (PokeAPI ID 7)

--- a/backend/init.sql
+++ b/backend/init.sql
@@ -1,9 +1,3 @@
--- Create the database
-CREATE DATABASE pokemon_db;
-
--- Connect to the database
-\c pokemon_db;
-
 -- Create the users table
 CREATE TABLE users (
     user_id SERIAL PRIMARY KEY,

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,6 +1,20 @@
 const express = require('express');
 const app = express();
 const axios = require('axios');
+const { Pool } = require('pg')
+
+const PORT = 3000;
+
+// PostgreSQL connection configuration
+const pool = new Pool({
+  user: 'youruser',
+  host: 'localhost',
+  database: 'pokemon_db',
+  password: 'yourpassword',
+  port: 5432,
+})
+
+app.use(express.json())
 
 // Example route to fetch Pokémon data from an external API
 app.get('/', async (req, res) => {
@@ -15,7 +29,31 @@ app.get('/', async (req, res) => {
   }
 });
 
-const PORT = 3000;
+app.get('/api/users/', async (req, res) => {
+  try {
+    const users = await pool.query('SELECT username FROM users');
+
+   if (users.rows.length === 0) {
+      return res.status(404).json({ message: 'No users found' });
+    }
+
+    res.json({ users: users.rows });
+  } catch (err) {
+    console.error('Error executing query:', err.message);
+    res.status(500).json({ error: 'Internal server error', details: err.message });
+  }
+});
+
+// Check database connection
+pool.connect()
+  .then(client => {
+    console.log('Database connected successfully');
+    client.release();
+  })
+  .catch(err => {
+    console.error('Database connection error:', err.message);
+  });
+
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
 });


### PR DESCRIPTION
This PR adds the code to initialize the database for our API.

The database contains two tables for now
- Users: storing `user_id`, `username`, `password`, and timestamps
- Favorites: storing `user_id`, `pokemon_id` and `user_pokemon` pair

to build the docker container and run it, use these commands

``` bash
docker build -t pokemon_db .
docker run --name pokedex_backend -d -p 5432:5432 pokemon_db
```

I added also the connection between the db and the server and an mock endpoint to return the user list.


Please @LeeRichi test that is working for you and you can get the user list before merging.
